### PR TITLE
Game manager title screen bug fix

### DIFF
--- a/Assets/IkTargetFallback.cs
+++ b/Assets/IkTargetFallback.cs
@@ -65,9 +65,11 @@ public class IkTargetFallback : MonoBehaviour
             IK_Target.transform.localRotation = Quaternion.Euler(IK_Target.transform.localRotation.x, IK_Target.transform.localRotation.y, IK_Target_ZRotLimit * tempZ); //apply the "clamped" x
         }
 
+        if (IK_Debug_X == null || IK_Debug_Y == null || IK_Debug_Z == null) {  return; }
         IK_Debug_X.text = "X: " + IK_Target.transform.eulerAngles.x + " " + IK_Target.transform.rotation.x;
         IK_Debug_Y.text = "Y: " + IK_Target.transform.eulerAngles.y + " " + IK_Target.transform.rotation.y;
         IK_Debug_Z.text = "Z: " + IK_Target.transform.eulerAngles.z + " " + IK_Target.transform.rotation.z;
+        if (VisualDebug == null) { return; }
         VisualDebug.transform.rotation = IK_Target.transform.rotation;
     }
 

--- a/Assets/LeggytheRobotArm/_Levels/00_Tutorial/Tutorial_00.unity
+++ b/Assets/LeggytheRobotArm/_Levels/00_Tutorial/Tutorial_00.unity
@@ -743,70 +743,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Transition
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_NormalColor.b
-      value: 0.8018868
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_NormalColor.g
-      value: 0.8018868
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_NormalColor.r
-      value: 0.8018868
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.b
-      value: 0.6188214
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.g
-      value: 0.735849
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.r
-      value: 0.28114986
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_DisabledColor.b
-      value: 0.4056604
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_DisabledColor.g
-      value: 0.4056604
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_DisabledColor.r
-      value: 0.4056604
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_SelectedColor.b
-      value: 0.41220188
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_SelectedColor.g
-      value: 0.53397924
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_SelectedColor.r
-      value: 0.5566038
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.b
-      value: 0.52186733
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.g
-      value: 0.5660378
-      objectReference: {fileID: 0}
-    - target: {fileID: 1563063168014204100, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.r
-      value: 0.4031684
-      objectReference: {fileID: 0}
     - target: {fileID: 1726530270542730623, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -858,134 +794,6 @@ PrefabInstance:
     - target: {fileID: 3928341203511379510, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
       propertyPath: m_Name
       value: GameManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Transition
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_NormalColor.b
-      value: 0.8018868
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_NormalColor.g
-      value: 0.8018868
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_NormalColor.r
-      value: 0.8018868
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.b
-      value: 0.6188214
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.g
-      value: 0.735849
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.r
-      value: 0.28114986
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_DisabledColor.b
-      value: 0.4056604
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_DisabledColor.g
-      value: 0.4056604
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_DisabledColor.r
-      value: 0.4056604
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_SelectedColor.b
-      value: 0.41220188
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_SelectedColor.g
-      value: 0.53397924
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_SelectedColor.r
-      value: 0.5566038
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.b
-      value: 0.52186733
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.g
-      value: 0.5660378
-      objectReference: {fileID: 0}
-    - target: {fileID: 4204988046155491274, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.r
-      value: 0.4031684
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Transition
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_NormalColor.b
-      value: 0.8018868
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_NormalColor.g
-      value: 0.8018868
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_NormalColor.r
-      value: 0.8018868
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.b
-      value: 0.6188214
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.g
-      value: 0.735849
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_PressedColor.r
-      value: 0.28114986
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_DisabledColor.b
-      value: 0.4056604
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_DisabledColor.g
-      value: 0.4056604
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_DisabledColor.r
-      value: 0.4056604
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_SelectedColor.b
-      value: 0.41220188
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_SelectedColor.g
-      value: 0.53397924
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_SelectedColor.r
-      value: 0.5566038
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.b
-      value: 0.52186733
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.g
-      value: 0.5660378
-      objectReference: {fileID: 0}
-    - target: {fileID: 5593458974216180771, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.r
-      value: 0.4031684
       objectReference: {fileID: 0}
     - target: {fileID: 6346406767286688292, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1049,7 +857,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6975970684401223607, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
       propertyPath: textFadeInTime
-      value: 5
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6975970684401223607, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
       propertyPath: transitionText
@@ -1058,15 +866,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6975970684401223607, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
       propertyPath: fadeToBlackTime
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6975970684401223607, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
       propertyPath: textFadeOutTime
-      value: 3
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6975970684401223607, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
       propertyPath: textFadeOutDelay
-      value: 3
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6975970684401223607, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
       propertyPath: happinessLossTickSpeed
@@ -2395,7 +2203,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d360d96a3510e824aa561dc40ba23e4f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  moveOn: 0
   tutorialStartDelay: 1.5
   blackScreen: {fileID: 1816199427}
   continueHint: {fileID: 2055303792}

--- a/Assets/Scenes/Title Screen.unity
+++ b/Assets/Scenes/Title Screen.unity
@@ -895,7 +895,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4bc765dfb72d73c4a9f98de77261a832, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  eventSystem: {fileID: 1711504193}
   gameOverManager: {fileID: 0}
 --- !u!4 &1057439930
 Transform:
@@ -912,6 +911,81 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1291213229
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1291213230}
+  - component: {fileID: 1291213232}
+  - component: {fileID: 1291213231}
+  m_Layer: 5
+  m_Name: HorizonBlockout
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1291213230
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1291213229}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 200}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2084351075}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 16000, y: 9000}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1291213231
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1291213229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1291213232
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1291213229}
+  m_CullTransparentMesh: 1
 --- !u!1 &1316331185
 GameObject:
   m_ObjectHideFlags: 0
@@ -2754,11 +2828,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
+  m_ReferencePixelsPerUnit: 72
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 1920, y: 1080}
-  m_ScreenMatchMode: 1
-  m_MatchWidthOrHeight: 0
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0.5
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
@@ -2799,6 +2873,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1291213230}
   - {fileID: 1373275773}
   - {fileID: 1539456241}
   - {fileID: 1494722430}


### PR DESCRIPTION
The game manager now implements a callback from the scene manager when loading into a scene which checks to ensure it is destroyed if loaded into the title screen or the level select. These checks are performed via build index!!! Thus, be cautious not to modify the title screen and level select from 0 and 1 in the index, respectively.

This also fixes a minor bug in the IK target fallback to prevent a null reference error. This also updates the title screen and tutorial to touch up game feel (image fitting & transition speed, respectively).