### PR TITLE
Updated Level 01 and 02. Bugfix for game manager.

### DIFF
--- a/Assets/LeggytheRobotArm/Sound/Scripts/AudioHandler.cs
+++ b/Assets/LeggytheRobotArm/Sound/Scripts/AudioHandler.cs
@@ -1,6 +1,7 @@
 using FMOD.Studio;
 using FMODUnity;
 using System.Collections;
+using Unity.VisualScripting;
 using UnityEngine;
 
 public class AudioHandler : MonoBehaviour
@@ -110,6 +111,16 @@ public class AudioHandler : MonoBehaviour
     public void PlayMusic()
     {
         if (!areBanksLoaded) { return; }
+        PLAYBACK_STATE temp;
+        if (musicInstance.isValid())
+        {
+            musicInstance.getPlaybackState(out temp);
+        } else {
+            temp = PLAYBACK_STATE.STOPPED;
+        }
+
+        if (temp == PLAYBACK_STATE.PLAYING) { return; }
+
         musicInstance = FMODUnity.RuntimeManager.CreateInstance(mainTheme);
         FMODUnity.RuntimeManager.AttachInstanceToGameObject(musicInstance, this.transform);
         musicInstance.start();

--- a/Assets/LeggytheRobotArm/Sound/Scripts/LeggyAudio.cs
+++ b/Assets/LeggytheRobotArm/Sound/Scripts/LeggyAudio.cs
@@ -88,22 +88,22 @@ public class LeggyAudio : MonoBehaviour
                 firstPersonListener.enabled = false;
                 break;
             case CameraView.LeftShoulder:
-                topDownListener.enabled = false;
                 leftListener.enabled = true;
+                topDownListener.enabled = false;
                 rightListener.enabled = false;
                 firstPersonListener.enabled = false;
                 break;
             case CameraView.RightShoulder:
+                rightListener.enabled = true;
                 topDownListener.enabled = false;
                 leftListener.enabled = false;
-                rightListener.enabled = true;
                 firstPersonListener.enabled = false;
                 break;
             case CameraView.FirstPerson:
+                firstPersonListener.enabled = true;
                 topDownListener.enabled = false;
                 leftListener.enabled = false;
                 rightListener.enabled = false;
-                firstPersonListener.enabled = true;
                 break;
             default:
                 break;

--- a/Assets/LeggytheRobotArm/_Levels/_ismaelLevels/_level 001.unity
+++ b/Assets/LeggytheRobotArm/_Levels/_ismaelLevels/_level 001.unity
@@ -699,6 +699,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: CameraManager
       objectReference: {fileID: 0}
+    - target: {fileID: 5751505460827579412, guid: a4965e978b904ba48a7f2dd822a7b46c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7033272415306135381, guid: a4965e978b904ba48a7f2dd822a7b46c, type: 3}
       propertyPath: m_LocalPosition.x
       value: 2.93
@@ -821,6 +825,84 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 6015143625497064043, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
   m_PrefabInstance: {fileID: 1814631408}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1134396585
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1134396588}
+  - component: {fileID: 1134396587}
+  - component: {fileID: 1134396586}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1134396586
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1134396585}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+--- !u!114 &1134396587
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1134396585}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1134396588
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1134396585}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1269283475 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4382696333498649279, guid: 00cd30d5df1350f4fb52f95632fc05be, type: 3}
@@ -978,6 +1060,63 @@ MonoBehaviour:
     mipBias: 0
     varianceClampScale: 0.9
     contrastAdaptiveSharpening: 0
+--- !u!1001 &1752904869
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5343113585847496348, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_Name
+      value: AudioHandlerObject
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
 --- !u!20 &1790676224 stripped
 Camera:
   m_CorrespondingSourceObject: {fileID: 1514874985318582534, guid: ba1c5e801ac7eb546a5080703912acb5, type: 3}
@@ -2648,3 +2787,5 @@ SceneRoots:
   - {fileID: 7582023715118946250}
   - {fileID: 4080413463609436658}
   - {fileID: 804285191}
+  - {fileID: 1134396588}
+  - {fileID: 1752904869}

--- a/Assets/LeggytheRobotArm/_Levels/_ismaelLevels/_level 002.unity
+++ b/Assets/LeggytheRobotArm/_Levels/_ismaelLevels/_level 002.unity
@@ -250,6 +250,63 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 6015143625497064043, guid: d5de8325115bcf2448adad4f6e29e2f1, type: 3}
   m_PrefabInstance: {fileID: 1810524389}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &272225637
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5343113585847496348, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_Name
+      value: AudioHandlerObject
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7596894824611215905, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 477efe195bbaec040bc059edbe518cab, type: 3}
 --- !u!1001 &305403549
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1375,6 +1432,84 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1599099618
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1599099621}
+  - component: {fileID: 1599099620}
+  - component: {fileID: 1599099619}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1599099619
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1599099618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: 132979c7deeeca9489e5660aef0ece0b, type: 3}
+  m_PointAction: {fileID: -348881856375432067, guid: 132979c7deeeca9489e5660aef0ece0b, type: 3}
+  m_MoveAction: {fileID: -2295710598864875722, guid: 132979c7deeeca9489e5660aef0ece0b, type: 3}
+  m_SubmitAction: {fileID: 8875165108341886291, guid: 132979c7deeeca9489e5660aef0ece0b, type: 3}
+  m_CancelAction: {fileID: -3808056949813564604, guid: 132979c7deeeca9489e5660aef0ece0b, type: 3}
+  m_LeftClickAction: {fileID: 7819923408759280171, guid: 132979c7deeeca9489e5660aef0ece0b, type: 3}
+  m_MiddleClickAction: {fileID: -2870675730005512282, guid: 132979c7deeeca9489e5660aef0ece0b, type: 3}
+  m_RightClickAction: {fileID: 7511179165424553806, guid: 132979c7deeeca9489e5660aef0ece0b, type: 3}
+  m_ScrollWheelAction: {fileID: -3088363267118644681, guid: 132979c7deeeca9489e5660aef0ece0b, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6639771699482680142, guid: 132979c7deeeca9489e5660aef0ece0b, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: -7187966000759188622, guid: 132979c7deeeca9489e5660aef0ece0b, type: 3}
+  m_DeselectOnBackgroundClick: 0
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+--- !u!114 &1599099620
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1599099618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1599099621
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1599099618}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1612297628
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2316,3 +2451,5 @@ SceneRoots:
   - {fileID: 1841130532}
   - {fileID: 1612297628}
   - {fileID: 1810524389}
+  - {fileID: 1599099621}
+  - {fileID: 272225637}

--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -92,19 +92,19 @@ public class CameraController : MonoBehaviour
 
         if (value.x < 0)
         {
+            leftShoulder.enabled = true;
             topDown.enabled = false;
             firstPerson.enabled = false;
-            leftShoulder.enabled = true;
             rightShoulder.enabled = false;
             if (leggyAudio != null) { leggyAudio.SetListener(LeggyAudio.CameraView.LeftShoulder); }
         }
 
         if (value.x > 0)
         {
+            rightShoulder.enabled = true;
             topDown.enabled = false;
             firstPerson.enabled = false;
             leftShoulder.enabled = false;
-            rightShoulder.enabled = true;
             if (leggyAudio != null) { leggyAudio.SetListener(LeggyAudio.CameraView.RightShoulder); }
         }
     }

--- a/Assets/Scripts/Rig Controls/RigControls.cs
+++ b/Assets/Scripts/Rig Controls/RigControls.cs
@@ -117,7 +117,7 @@ public class RigControls : MonoBehaviour
     void Update()
     {
         hightMultiplier = ArmIK_target.transform.localPosition.y / ikMaxY;
-        Debug.Log(hightMultiplier + " " + ArmIK_target.transform.localPosition.y + " " + ikMaxY);
+        // Debug.Log(hightMultiplier + " " + ArmIK_target.transform.localPosition.y + " " + ikMaxY);
         ikModifiedMinX = ikMinRotationX * hightMultiplier * 1.2f;
         ikModifiedMaxX = ikMaxRotationX * hightMultiplier * 1.2f;
 


### PR DESCRIPTION
The game manager was not appropriately destroying old game managers when loading into a level due to checks that were not agnostic of hierarchy position.

Updated level 01 and 02 to have default audio handlers (for testing purposes) and event systems to allow for pausing.

Updated camera controller and rig controls to ensure an FMOD Studio Listener was always present when switching cameras.

Updated audio handler to prevent duplicate instances of music playing.